### PR TITLE
Fixe la version de python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Adrien Di Pasquale <adrien.di_pasquale@beta.gouv.fr>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "3.9"
 requests = "^2"
 Scrapy = "^2"
 scrapinghub = "^2"


### PR DESCRIPTION
La commande `poetry install` échoue avec Python 3.13. En bloquant à 3.9 pas de souci. Il y a peut-être moyen de mettre à jour toutes les dépendances, mais si on veut juste faire fonctionner le projet, c'est le plus rapide.